### PR TITLE
Migrate to factory bean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group 'org.thepavel'
-version '1.0.0'
+version '1.0.1'
 
 sourceCompatibility = 1.8
 

--- a/src/main/java/org/thepavel/icomponent/metadata/factory/ClassMetadataFactoryBean.java
+++ b/src/main/java/org/thepavel/icomponent/metadata/factory/ClassMetadataFactoryBean.java
@@ -23,13 +23,13 @@ import org.thepavel.icomponent.generic.GenericTypeParametersResolver;
 import org.thepavel.icomponent.metadata.ClassMetadata;
 import org.thepavel.icomponent.metadata.ClassMetadataImpl;
 
-import static org.springframework.util.ClassUtils.resolveClassName;
+import static org.thepavel.icomponent.util.AnnotationMetadataHelper.getSourceClass;
 
 @Component(ClassMetadataFactory.NAME)
 public class ClassMetadataFactoryBean implements ClassMetadataFactory {
   @Override
   public ClassMetadata getClassMetadata(AnnotationMetadata annotationMetadata) {
-    Class<?> annotatedClass = getClass(annotationMetadata);
+    Class<?> annotatedClass = getSourceClass(annotationMetadata);
     MergedAnnotations annotations = annotationMetadata.getAnnotations();
 
     ClassMetadataImpl classMetadata = new ClassMetadataImpl(annotatedClass, annotations);
@@ -39,10 +39,6 @@ public class ClassMetadataFactoryBean implements ClassMetadataFactory {
         .forEach(classMetadata::addMethodMetadata);
 
     return classMetadata;
-  }
-
-  private static Class<?> getClass(AnnotationMetadata annotationMetadata) {
-    return resolveClassName(annotationMetadata.getClassName(), null);
   }
 
   private static MethodMetadataFactory getMethodMetadataFactory(Class<?> clazz) {

--- a/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentInterceptor.java
+++ b/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentInterceptor.java
@@ -18,10 +18,12 @@ package org.thepavel.icomponent.proxy;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.util.ReflectionUtils;
 import org.thepavel.icomponent.handler.MethodHandler;
 import org.thepavel.icomponent.handler.MethodHandlerMap;
 import org.thepavel.icomponent.metadata.ClassMetadata;
 import org.thepavel.icomponent.metadata.MethodMetadata;
+import org.thepavel.icomponent.util.MethodInvocationHelper;
 
 import java.lang.reflect.Method;
 
@@ -45,6 +47,10 @@ public class InterfaceComponentInterceptor implements MethodInterceptor {
   @Override
   public Object invoke(MethodInvocation invocation) {
     Method method = invocation.getMethod();
+
+    if (ReflectionUtils.isToStringMethod(method)) {
+      return MethodInvocationHelper.getToStringValueFor(invocation);
+    }
 
     MethodMetadata methodMetadata = classMetadata.getMethodMetadata(method);
     MethodHandler methodHandler = methodHandlerMap.getMethodHandler(method);

--- a/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactory.java
+++ b/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactory.java
@@ -32,7 +32,6 @@ import java.util.List;
 public class InterfaceComponentProxyFactory {
   public static final String NAME =
       "org.thepavel.icomponent.proxy.internalInterfaceComponentProxyFactory";
-  public static final String METHOD_NAME = "createProxy";
 
   private final ClassMetadataFactory classMetadataFactory;
   private final List<ClassMetadataValidator> classMetadataValidators;
@@ -49,7 +48,6 @@ public class InterfaceComponentProxyFactory {
     this.interceptorFactory = interceptorFactory;
   }
 
-  @SuppressWarnings("unused")
   public Object createProxy(AnnotationMetadata annotationMetadata) {
     ClassMetadata classMetadata = getClassMetadata(annotationMetadata);
     validateClassMetadata(classMetadata);

--- a/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactory.java
+++ b/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactory.java
@@ -16,7 +16,7 @@
 
 package org.thepavel.icomponent.proxy;
 
-import org.springframework.aop.framework.ProxyFactoryBean;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.BeanInstantiationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.type.AnnotationMetadata;
@@ -71,10 +71,7 @@ public class InterfaceComponentProxyFactory {
   }
 
   private Object createProxy(ClassMetadata classMetadata) {
-    ProxyFactoryBean proxyFactoryBean = new ProxyFactoryBean();
-    proxyFactoryBean.setInterfaces(classMetadata.getSourceClass());
-    proxyFactoryBean.addAdvice(getInterceptor(classMetadata));
-    return proxyFactoryBean.getObject();
+    return ProxyFactory.getProxy(classMetadata.getSourceClass(), getInterceptor(classMetadata));
   }
 
   private InterfaceComponentInterceptor getInterceptor(ClassMetadata classMetadata) {

--- a/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactoryBean.java
+++ b/src/main/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactoryBean.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.proxy;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.type.AnnotationMetadata;
+
+import static org.thepavel.icomponent.util.AnnotationMetadataHelper.getSourceClass;
+
+public class InterfaceComponentProxyFactoryBean implements FactoryBean<Object> {
+  private final AnnotationMetadata metadata;
+  private final Class<?> objectType;
+
+  private InterfaceComponentProxyFactory proxyFactory;
+
+  public InterfaceComponentProxyFactoryBean(AnnotationMetadata metadata) {
+    this.metadata = metadata;
+    objectType = getSourceClass(metadata);
+  }
+
+  @Autowired
+  public void setProxyFactory(InterfaceComponentProxyFactory proxyFactory) {
+    this.proxyFactory = proxyFactory;
+  }
+
+  @Override
+  public Object getObject() {
+    return proxyFactory.createProxy(metadata);
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return objectType;
+  }
+}

--- a/src/main/java/org/thepavel/icomponent/registrar/InterfaceComponentBeanFactoryPostProcessor.java
+++ b/src/main/java/org/thepavel/icomponent/registrar/InterfaceComponentBeanFactoryPostProcessor.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.stereotype.Component;
-import org.thepavel.icomponent.proxy.InterfaceComponentProxyFactory;
+import org.thepavel.icomponent.proxy.InterfaceComponentProxyFactoryBean;
 import org.thepavel.icomponent.util.BeanDefinitionHelper;
 
 import java.util.Arrays;
@@ -42,11 +42,14 @@ public class InterfaceComponentBeanFactoryPostProcessor implements BeanFactoryPo
   }
 
   private void setFactoryBean(AnnotatedBeanDefinition beanDefinition) {
-    beanDefinition.setFactoryBeanName(InterfaceComponentProxyFactory.NAME);
-    beanDefinition.setFactoryMethodName(InterfaceComponentProxyFactory.METHOD_NAME);
+    beanDefinition.setBeanClassName(getFactoryBeanClassName());
 
     beanDefinition
         .getConstructorArgumentValues()
         .addGenericArgumentValue(beanDefinition.getMetadata());
+  }
+
+  protected String getFactoryBeanClassName() {
+    return InterfaceComponentProxyFactoryBean.class.getName();
   }
 }

--- a/src/main/java/org/thepavel/icomponent/util/AnnotationMetadataHelper.java
+++ b/src/main/java/org/thepavel/icomponent/util/AnnotationMetadataHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.util;
+
+import org.springframework.core.type.AnnotationMetadata;
+
+import static org.springframework.util.ClassUtils.resolveClassName;
+
+public class AnnotationMetadataHelper {
+  private AnnotationMetadataHelper() {
+  }
+
+  public static Class<?> getSourceClass(AnnotationMetadata metadata) {
+    return resolveClassName(metadata.getClassName(), null);
+  }
+}

--- a/src/main/java/org/thepavel/icomponent/util/MethodInvocationHelper.java
+++ b/src/main/java/org/thepavel/icomponent/util/MethodInvocationHelper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.util;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.ProxyMethodInvocation;
+
+public class MethodInvocationHelper {
+  private MethodInvocationHelper() {
+  }
+
+  public static String getToStringValueFor(MethodInvocation invocation) {
+    Object proxy = ((ProxyMethodInvocation) invocation).getProxy();
+    return proxy.getClass().getName() + "@" + Integer.toHexString(proxy.hashCode());
+  }
+}

--- a/src/test/java/org/thepavel/icomponent/proxy/DummyMethodInvocation.java
+++ b/src/test/java/org/thepavel/icomponent/proxy/DummyMethodInvocation.java
@@ -17,17 +17,24 @@
 package org.thepavel.icomponent.proxy;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.aop.ProxyMethodInvocation;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
 
-class DummyMethodInvocation implements MethodInvocation {
+class DummyMethodInvocation implements ProxyMethodInvocation {
+  private final Object proxy = new Object();
   private final Method method;
   private final Object[] arguments;
 
   public DummyMethodInvocation(Method method, Object[] arguments) {
     this.method = method;
     this.arguments = arguments;
+  }
+
+  @Override
+  public Object getProxy() {
+    return proxy;
   }
 
   @Override
@@ -52,6 +59,29 @@ class DummyMethodInvocation implements MethodInvocation {
 
   @Override
   public AccessibleObject getStaticPart() {
+    return null;
+  }
+
+  @Override
+  public MethodInvocation invocableClone() {
+    return null;
+  }
+
+  @Override
+  public MethodInvocation invocableClone(Object... arguments) {
+    return null;
+  }
+
+  @Override
+  public void setArguments(Object... arguments) {
+  }
+
+  @Override
+  public void setUserAttribute(String key, Object value) {
+  }
+
+  @Override
+  public Object getUserAttribute(String key) {
     return null;
   }
 }

--- a/src/test/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactoryBeanTest.java
+++ b/src/test/java/org/thepavel/icomponent/proxy/InterfaceComponentProxyFactoryBeanTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.proxy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.type.AnnotationMetadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@SuppressWarnings("SameParameterValue")
+public class InterfaceComponentProxyFactoryBeanTest {
+  @Test
+  public void providesObjectType() {
+    givenAnnotationMetadataFor(InterfaceComponentProxyFactoryBeanTest.class);
+    whenProxyFactoryBeanCreated();
+    thenProxyFactoryBeanHasObjectType(InterfaceComponentProxyFactoryBeanTest.class);
+  }
+
+  @Test
+  public void delegatesToProxyFactory() {
+    Object object = new Object();
+
+    givenAnnotationMetadataFor(InterfaceComponentProxyFactoryBeanTest.class);
+    andProxyFactoryReturning(object);
+    whenProxyFactoryBeanCreated();
+    thenProxyFactoryBeanReturnsObject(object);
+  }
+
+  private AnnotationMetadata annotationMetadata;
+  private InterfaceComponentProxyFactoryBean proxyFactoryBean;
+  private Object proxyObject;
+
+  @BeforeEach
+  public void beforeEach() {
+    annotationMetadata = null;
+    proxyFactoryBean = null;
+    proxyObject = null;
+  }
+
+  private void givenAnnotationMetadataFor(Class<?> clazz) {
+    annotationMetadata = AnnotationMetadata.introspect(clazz);
+  }
+
+  private void andProxyFactoryReturning(Object proxyObject) {
+    this.proxyObject = proxyObject;
+  }
+
+  private void whenProxyFactoryBeanCreated() {
+    proxyFactoryBean = new InterfaceComponentProxyFactoryBean(annotationMetadata);
+    proxyFactoryBean.setProxyFactory(new DummyProxyFactory());
+  }
+
+  private void thenProxyFactoryBeanHasObjectType(Class<?> expected) {
+    assertEquals(expected, proxyFactoryBean.getObjectType());
+  }
+
+  private void thenProxyFactoryBeanReturnsObject(Object expected) {
+    assertSame(expected, proxyFactoryBean.getObject());
+  }
+
+  private class DummyProxyFactory extends InterfaceComponentProxyFactory {
+    private DummyProxyFactory() {
+      super(null, null, null);
+    }
+
+    @Override
+    public Object createProxy(AnnotationMetadata annotationMetadata) {
+      return proxyObject;
+    }
+  }
+}

--- a/src/test/java/org/thepavel/icomponent/registrar/InterfaceComponentBeanFactoryPostProcessorTest.java
+++ b/src/test/java/org/thepavel/icomponent/registrar/InterfaceComponentBeanFactoryPostProcessorTest.java
@@ -21,18 +21,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues.ValueHolder;
-import org.thepavel.icomponent.proxy.InterfaceComponentProxyFactory;
+import org.thepavel.icomponent.proxy.InterfaceComponentProxyFactoryBean;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class InterfaceComponentBeanFactoryPostProcessorTest {
   @Test
-  public void assignsFactoryMethodForInterfaces() {
+  public void setsBeanClassNameToFactoryBeanClassName() {
     givenBeanDefinitionFor(TestInterface.class);
     whenInterfaceComponentBeanFactoryPostProcessorRan();
-    thenBeanDefinitionHasFactoryBeanName(InterfaceComponentProxyFactory.NAME);
-    andBeanDefinitionHasFactoryMethodName(InterfaceComponentProxyFactory.METHOD_NAME);
+    thenBeanDefinitionHasBeanClassName(InterfaceComponentProxyFactoryBean.class.getName());
     andBeanDefinitionHasConstructorArguments(beanDefinition.getMetadata());
   }
 
@@ -40,8 +39,7 @@ public class InterfaceComponentBeanFactoryPostProcessorTest {
   public void ignoresAbstractClasses() {
     givenBeanDefinitionFor(TestAbstractClass.class);
     whenInterfaceComponentBeanFactoryPostProcessorRan();
-    thenBeanDefinitionHasFactoryBeanName(null);
-    andBeanDefinitionHasFactoryMethodName(null);
+    thenBeanDefinitionHasBeanClassName(TestAbstractClass.class.getName());
     andBeanDefinitionHasConstructorArguments();
   }
 
@@ -49,8 +47,7 @@ public class InterfaceComponentBeanFactoryPostProcessorTest {
   public void ignoresConcreteClasses() {
     givenBeanDefinitionFor(TestClass.class);
     whenInterfaceComponentBeanFactoryPostProcessorRan();
-    thenBeanDefinitionHasFactoryBeanName(null);
-    andBeanDefinitionHasFactoryMethodName(null);
+    thenBeanDefinitionHasBeanClassName(TestClass.class.getName());
     andBeanDefinitionHasConstructorArguments();
   }
 
@@ -70,12 +67,8 @@ public class InterfaceComponentBeanFactoryPostProcessorTest {
         .postProcessBeanFactory(new DummyConfigurableListableBeanFactory(beanDefinition));
   }
 
-  private void thenBeanDefinitionHasFactoryBeanName(String beanName) {
-    assertEquals(beanName, beanDefinition.getFactoryBeanName());
-  }
-
-  private void andBeanDefinitionHasFactoryMethodName(String methodName) {
-    assertEquals(methodName, beanDefinition.getFactoryMethodName());
+  private void thenBeanDefinitionHasBeanClassName(String expected) {
+    assertEquals(expected, beanDefinition.getBeanClassName());
   }
 
   private void andBeanDefinitionHasConstructorArguments(Object... arguments) {

--- a/src/test/java/org/thepavel/icomponent/util/AnnotationMetadataHelperTest.java
+++ b/src/test/java/org/thepavel/icomponent/util/AnnotationMetadataHelperTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.type.AnnotationMetadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings("SameParameterValue")
+public class AnnotationMetadataHelperTest {
+  @Test
+  public void resolvesClassNameIntoClass() {
+    givenAnnotationMetadataFor(AnnotationMetadataHelperTest.class);
+    whenClassResolved();
+    thenResolvedClassIs(AnnotationMetadataHelperTest.class);
+  }
+
+  private AnnotationMetadata metadata;
+  private Class<?> resolvedClass;
+
+  @BeforeEach
+  public void beforeEach() {
+    metadata = null;
+    resolvedClass = null;
+  }
+
+  private void givenAnnotationMetadataFor(Class<?> clazz) {
+    metadata = AnnotationMetadata.introspect(clazz);
+  }
+
+  private void whenClassResolved() {
+    resolvedClass = AnnotationMetadataHelper.getSourceClass(metadata);
+  }
+
+  private void thenResolvedClassIs(Class<?> expected) {
+    assertEquals(expected, resolvedClass);
+  }
+}

--- a/src/test/java/org/thepavel/icomponent/util/MethodInvocationHelperTest.java
+++ b/src/test/java/org/thepavel/icomponent/util/MethodInvocationHelperTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020-2021 Pavel Grigorev.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.thepavel.icomponent.util;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.ProxyMethodInvocation;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MethodInvocationHelperTest {
+  @Test
+  public void replicatesToStringOfObject() {
+    Object object = new Object();
+    String value = MethodInvocationHelper.getToStringValueFor(new DummyInvocation(object));
+
+    assertEquals(object.toString(), value);
+  }
+
+  private static class DummyInvocation implements ProxyMethodInvocation {
+    private final Object proxy;
+
+    private DummyInvocation(Object proxy) {
+      this.proxy = proxy;
+    }
+
+    @Override
+    public Object getProxy() {
+      return proxy;
+    }
+
+    @Override
+    public MethodInvocation invocableClone() {
+      return null;
+    }
+
+    @Override
+    public MethodInvocation invocableClone(Object... arguments) {
+      return null;
+    }
+
+    @Override
+    public void setArguments(Object... arguments) {
+    }
+
+    @Override
+    public void setUserAttribute(String key, Object value) {
+    }
+
+    @Override
+    public Object getUserAttribute(String key) {
+      return null;
+    }
+
+    @Override
+    public Method getMethod() {
+      return null;
+    }
+
+    @Override
+    public Object[] getArguments() {
+      return new Object[0];
+    }
+
+    @Override
+    public Object proceed() {
+      return null;
+    }
+
+    @Override
+    public Object getThis() {
+      return null;
+    }
+
+    @Override
+    public AccessibleObject getStaticPart() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Instead of setting factoryBeanClass and factoryMethodName on a BeanDefinition object, it now sets beanClassName to InterfaceComponentProxyFactoryBean which is a FactoryBean delegating to InterfaceComponentProxyFactory. With this approach there's more chance for Spring to resolve the bean class.